### PR TITLE
Add support for ub1204

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ npm-debug.log
 /attic
 metadata.json
 /vendor
+
+#Rubymine
+.idea

--- a/cookbook/metadata.rb
+++ b/cookbook/metadata.rb
@@ -11,7 +11,7 @@ depends 'apt'
 depends 'database', '~> 4.0'
 depends 'mysql', '~> 6.0'
 depends 'mysql2_chef_gem', '~> 1.0'
-
+depends 'redisio'
 # depends 'libarchive', '>= 0.5.0'
 
 supports 'ubuntu'

--- a/cookbook/recipes/database.rb
+++ b/cookbook/recipes/database.rb
@@ -21,7 +21,7 @@
 ##
 # XXX: This configuration is currently for testing purposes only!
 ##
-package 'redis-server'
+package 'redis-server' unless node.platform_version == "12.04"
 
 mysql_service 'guardian' do
   port '3306'

--- a/cookbook/recipes/default.rb
+++ b/cookbook/recipes/default.rb
@@ -24,3 +24,7 @@ include_recipe "#{ cookbook_name }::service-session"
 include_recipe "#{ cookbook_name }::service-authn"
 # include_recipe "#{ cookbook_name }::service-authz"
 include_recipe "#{ cookbook_name }::service-router"
+if node.platform_version == "12.04"
+  include_recipe "redisio::default"
+  include_recipe "redisio::enable"
+end


### PR DESCRIPTION
This adds support for ub1204. This was done as we needed to support a newer version of redis then the default isntalled by the redis cookbook on 1204. @jmanero-r7 Please let me know what if you need anything from me to merge this.