### PR TITLE
Include upstream Set-Cookie headers in proxied responses

### DIFF
--- a/lib/mw/cookie.js
+++ b/lib/mw/cookie.js
@@ -41,9 +41,13 @@ exports.attach = function(app) {
     // Add Set-Cookie headers before request ends
     res.cookies = {};
     res.before('headers', function() {
-      this.setHeader('Set-Cookie', Object.keys(res.cookies).map(function(name) {
-        return res.cookies[name].serialize();
-      }));
+      this.setHeader('Set-Cookie',
+        (res.get('set-cookie') || []).concat(
+          Object.keys(res.cookies).map(function(name) {
+            return res.cookies[name].serialize();
+          })
+        )
+      );
     });
 
     // No request cookies. Carry on.


### PR DESCRIPTION
Previously we overwrote the upstream proxied Set-Cookie header when setting the guardian cookie.  This commit ensures guardian cookies are appended to the upstream `Set-Cookie` header instead of replacing it.

The `Proxy` object copies all headers from the upstream response to the `Express` response.  This includes the `Set-Cookie` header.  The guardian cookie middleware overwrites the `Set-Cookie` header using the `cookie` attribute.  This PR adds support for appending cookies in the `cookie` attribute to existing `Set-Cookie` headers.  For non-proxy requests, the `Set-Cookie` header shouldn't already exist and this PR is a no-op.

cc @jmanero-r7, @bcall-r7, @asebastian-r7