### PR TITLE
Don't set guardian version if set in attributes

### DIFF
--- a/cookbook/recipes/base.rb
+++ b/cookbook/recipes/base.rb
@@ -21,7 +21,7 @@
 include_recipe 'apt'
 include_recipe "#{ cookbook_name }::nodejs"
 
-node.default['guardian']['version'] = cookbook_version
+node.default_unless['guardian']['version'] = cookbook_version
 
 group node['guardian']['group'] do
   system true


### PR DESCRIPTION
This prevents overriding the git version set in an attributes file.

Prior to this pull request, the only way to change the git commit deployed with this cookbook was to use an `override` attribute.  We should be able to use `default` attributes in wrapper cookbooks and limit the use of `override` for unique situations.