### PR TITLE
Cleanup resource notifications

### DIFF
--- a/cookbook/providers/service.rb
+++ b/cookbook/providers/service.rb
@@ -46,6 +46,11 @@ action :create do
     variables :content => {
       new_resource.name => node['guardian'][new_resource.name]
     }
+
+    ## Restart if the service is enabled
+    notifies :restart,
+             :service => "guardian-#{ new_resource.name }" if
+               new_resource.enabled
   end
 
   service "guardian-#{ new_resource.name }" do

--- a/cookbook/recipes/service-authn.rb
+++ b/cookbook/recipes/service-authn.rb
@@ -20,4 +20,7 @@
 include_recipe "#{ cookbook_name }::base"
 include_recipe "#{ cookbook_name }::install"
 
-guardian_service 'authn'
+guardian_service 'authn' do
+  subscribes :reload, 'git[guardian-source]', :delayed
+  subscribes :reload, 'ruby_block[guardian-source]', :delayed
+end

--- a/cookbook/recipes/service-authz.rb
+++ b/cookbook/recipes/service-authz.rb
@@ -20,4 +20,7 @@
 include_recipe "#{ cookbook_name }::base"
 include_recipe "#{ cookbook_name }::install"
 
-guardian_service 'authz'
+guardian_service 'authz' do
+  subscribes :reload, 'git[guardian-source]', :delayed
+  subscribes :reload, 'ruby_block[guardian-source]', :delayed
+end

--- a/cookbook/recipes/service-router.rb
+++ b/cookbook/recipes/service-router.rb
@@ -20,4 +20,7 @@
 include_recipe "#{ cookbook_name }::base"
 include_recipe "#{ cookbook_name }::install"
 
-guardian_service 'router'
+guardian_service 'router' do
+  subscribes :reload, 'git[guardian-source]', :delayed
+  subscribes :reload, 'ruby_block[guardian-source]', :delayed
+end

--- a/cookbook/recipes/service-session.rb
+++ b/cookbook/recipes/service-session.rb
@@ -20,4 +20,7 @@
 include_recipe "#{ cookbook_name }::base"
 include_recipe "#{ cookbook_name }::install"
 
-guardian_service 'session'
+guardian_service 'session' do
+  subscribes :reload, 'git[guardian-source]', :delayed
+  subscribes :reload, 'ruby_block[guardian-source]', :delayed
+end

--- a/cookbook/recipes/source-github-master.rb
+++ b/cookbook/recipes/source-github-master.rb
@@ -31,9 +31,12 @@ git 'guardian-source' do
 
   user node['guardian']['user']
   group node['guardian']['group']
+
+  notifies :run, 'execute[guardian-npm-install]', :immediately
 end
 
-execute 'npm-install' do
+execute 'guardian-npm-install' do
+  action :nothing # will be notified when source is changed
   command "#{ node['nodejs']['npm'] } install"
   cwd node['guardian']['path']
   user node['guardian']['user']

--- a/cookbook/recipes/source-github-tag.rb
+++ b/cookbook/recipes/source-github-tag.rb
@@ -31,9 +31,12 @@ git 'guardian-source' do
 
   user node['guardian']['user']
   group node['guardian']['group']
+
+  notifies :run, 'execute[guardian-npm-install]', :immediately
 end
 
-execute 'npm-install' do
+execute 'guardian-npm-install' do
+  action :nothing # will be notified when source is changed
   command "#{ node['nodejs']['npm'] } install"
   cwd node['guardian']['path']
   user node['guardian']['user']

--- a/cookbook/recipes/source-local.rb
+++ b/cookbook/recipes/source-local.rb
@@ -29,9 +29,11 @@ ruby_block 'guardian-source' do
     Chef::Application.fatal!('Unable to find Guardian source at ' +
       node['guardian']['path']) unless ::File.exist?(::File.join(node['guardian']['path'], 'package.json'))
   end
+  notifies :run, 'execute[guardian-npm-install]', :immediately
 end
 
-execute 'npm-install' do
+execute 'guardian-npm-install' do
+  action :nothing # will be notified when source is changed
   command "#{ node['nodejs']['npm'] } install"
   cwd node['guardian']['path']
   user node['guardian']['user']


### PR DESCRIPTION
This ensures guardian is restarted when the following events occur:
* git source is updated
* guardian configuration files are changed

This also prevents `npm install` from running on every chef run.  It now only runs when the source changes.