### PR TITLE
Fix a bug with duplicate pathnames

### DIFF
--- a/lib/util/client/proxy.js
+++ b/lib/util/client/proxy.js
@@ -27,7 +27,7 @@ Proxy.prototype.request = function(req, res, next) {
   var _this = this;
 
   var preq = Proxy.request(req.method, Client.mergeOptions({
-    pathname: reqPath.call(this, req.path),
+    pathname: req.path,
     query: req.query,
     headers: reqHeaders.call(this, req),
   }, this.options));
@@ -66,13 +66,6 @@ Proxy.prototype.request = function(req, res, next) {
 
   req.pipe(preq);
 };
-
-/**
- * Rewrite request path before sending to upstream
- */
-function reqPath(path) {
-  return Path.join(this.upstream.pathname, path);
-}
 
 /**
  * Rewrite request headers before sending to upstream


### PR DESCRIPTION
When you define a pathname in the router, proxy requests duplicate this pathname.

For example, with a router.json of:

```
{
  "router": {
    "routes": {
      "/elasticsearch": {
        "protocol": "http:",
        "hostname": "localhost",
        "port": 8081,
        "pathname": "/foo"
      }
    }
  }
}
```

a proxy request to https://guardian/elasticsearch/bar will get routed to http://localhost:8081**/foo/foo**/bar.

The pathname is already being merged as part of Client.mergeOptions, so there is no reason to do this as part of the Proxy request.