### PR TITLE
Add default route option for each SAML provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ SAML providers should contain the following parameters:
 * **name**: A unique name for the provider
 * **stategy**: SAML
 * **certificate**: A file containing the identity providers X.509 certificate
+* **defaultRoute**: The URL to redirect to after authentication if no return path
+  is set (defaults to '/')
 * **params.issuer**: The Entity ID / Issuer from the identity provider
 * **params.identifierFormat**:  The name ID format used by the identity provider.
   This is usually `urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified`.

--- a/lib/control/strategy/saml.js
+++ b/lib/control/strategy/saml.js
@@ -68,7 +68,7 @@ exports.initialize = function(app, id, options) {
       failureRedirect: Config.get('authn:prefix') + '/login/failure',
     }),
     function(req, res) {
-      res.redirect(req.session.returnTo || '/');
+      res.redirect(req.session.returnTo || options.defaultRoute || '/');
       delete req.session.returnTo;
     });
 


### PR DESCRIPTION
By default, if the user goes directly to the SAML callback URL (without
visiting the app first), they are redirected to '/' after
authentication.

This allows setting a default route to redirect to if no return path is
set.  You can configure this in the authn.json config file:

```json
{
  "authn": {
    "providers": {
      "myprovider: {
        "name": "My Provider",
        "strategy": "SAML",
        "defaultRoute": "/uadmin/",
        "params": {}
      }
    }
  }
}
```