### PR TITLE
CORE-1445: Added copytruncate option to logrotate

### DIFF
--- a/cookbook/recipes/logging.rb
+++ b/cookbook/recipes/logging.rb
@@ -23,7 +23,7 @@ logrotate_app 'guardian' do
   path node['guardian']['log']
   enable true
   frequency 'daily'
-  options %w(missingok notifempty compress)
+  options %w(missingok notifempty compress copytruncate)
   rotate 30
   create '644 root adm'
 end


### PR DESCRIPTION
Nodejs uses file descriptors to hold log files open for writing. When logrotate rotates the file, it moves the file on disk but node keeps the file descriptor open and continues to write to it. Consequently logs aren't actually written to disk and remain in a Schrödinger's cat-like state where they exist but don't actually exist.

Adding `copytruncate` to logrotate's options copies the log and then truncates it, allowing node's file descriptor to stay active and continue to write logs.