### PR TITLE
Pass proxied querystrings thru unmodified

### DIFF
--- a/lib/util/client.js
+++ b/lib/util/client.js
@@ -31,7 +31,14 @@ Client.request = function(method, options, callback) {
 
   options.method = method;
   options.path = options.pathname;
-  if (options.query &&
+  // If querystring is set use it instead of the query object.
+  // The Proxy client uses querystring directly to ensure QS.stringify doesn't change the
+  // original querystring format.
+  // For example, "foo=1&foo=2" might be translated to "foo[0]=1&foo[1]=2" by
+  // QS.stringify, which may not be understood by the proxied app.
+  if (options.querystring)
+    options.path += '?' + options.querystring;
+  else if (options.query &&
     Object.keys(options.query).length > 0) options.path += '?' + QS.stringify(options.query);
 
   var req = protocol(options).request(options);

--- a/lib/util/client/proxy.js
+++ b/lib/util/client/proxy.js
@@ -28,7 +28,7 @@ Proxy.prototype.request = function(req, res, next) {
 
   var preq = Proxy.request(req.method, Client.mergeOptions({
     pathname: req.path,
-    query: req.query,
+    querystring: URL.parse(req.url).query,
     headers: reqHeaders.call(this, req),
   }, this.options));
 


### PR DESCRIPTION
Previously, guardian would sometimes alter the format of a querystring when proxying to the upstream server.  This often happened with array values.

For example:

```
/someurl?foo=1&foo=2&foo=3
```

would be passed to the upstream server as:

```
/someurl?foo[0]=1&foo[1]=2&foo[2]=3
```

Some upstream servers don't understand this format.

This PR changes guardian's behavior to always pass the querystring unmodified on proxied requests.