### PR TITLE
Disable apparmor w/ monkey patch

### DIFF
--- a/cookbook/libraries/helpers.rb
+++ b/cookbook/libraries/helpers.rb
@@ -25,3 +25,12 @@ module Guardian
     end
   end
 end
+
+module MysqlCookbook
+  class MysqlServiceManagerSystemd
+
+    def configure_apparmor
+    end
+
+  end
+end


### PR DESCRIPTION
Upstream apparmor cookbook is broken, disabling for now.