### PR TITLE
PD-26578 bump metadata

### DIFF
--- a/cookbook/metadata.rb
+++ b/cookbook/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures guardian'
 
 license 'MIT'
 long_description IO.read(File.expand_path('../../README.md', __FILE__)) rescue ''
-version '0.3.28'
+version '0.3.29'
 
 depends 'apt'
 depends 'database', '~> 4.0'


### PR DESCRIPTION
This PR bumps the metadata version to avoid the issue in the following jenkins build: https://razorci.osdc.lax.rapid7.com/job/chef-guardian-master/12/console