### PR TITLE
PD-27904 bump nodejs version and metadata

### DIFF
--- a/cookbook/metadata.rb
+++ b/cookbook/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures guardian'
 
 license 'MIT'
 long_description IO.read(File.expand_path('../../README.md', __FILE__)) rescue ''
-version '0.3.29'
+version '0.3.30'
 
 depends 'apt'
 depends 'database', '~> 4.0'

--- a/cookbook/recipes/nodejs.rb
+++ b/cookbook/recipes/nodejs.rb
@@ -27,6 +27,6 @@ end
 
 package 'build-essential'
 package 'nodejs' do
-  version '10.22.1-1nodesource1'
+  version '10.23.0-1nodesource1'
 end
 package 'uuid-dev'


### PR DESCRIPTION
This PR bumps the node version because the previous one no longer exists. Also bumps the metadata version