### PR TITLE
PD-29629 Migrated berks-api off of razorci and replaced with chef org

### DIFF
--- a/cookbook/Berksfile
+++ b/cookbook/Berksfile
@@ -2,7 +2,7 @@
 require 'builderator/util/berkshim'
 extend Builderator::Util::Berkshim
 
-source 'http://razorci.osdc.lax.rapid7.com:9080'
+source 'http://chef.rapid7.com:9080'  # Core chef org
 source 'https://supermarket.getchef.com'
 
 #Replaces shims with metadata to run test kitchen


### PR DESCRIPTION
## Description
- Ref [PD-29629](https://issues.corp.rapid7.com/browse/PD-29629)
- Migrated berks-api off of razorci by replacing:
> source 'http://razorci.osdc.lax.rapid7.com:9080' 

With core chef org:
> source 'http://chef.rapid7.com:9080'  # Core chef org
## Testing
- [ ] `curl  http://chef.rapid7.com:9080/universe`